### PR TITLE
Fix partialy error on integrity check

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -67,6 +67,6 @@ clear_env = no
 ; Additional php.ini defines, specific to this pool of workers.
 php_value[upload_max_filesize] = 10G
 php_value[post_max_size] = 10G
-php_value[session.save_path] = #DESTDIR#/lib/private/session/
+; php_value[session.save_path] = #DESTDIR#/lib/private/session/
 php_value[default_charset] = UTF-8
 php_value[always_populate_raw_post_data] = -1


### PR DESCRIPTION
By creating all theses files inside the owncloud folder we obtain a lot of failure. In addition by modifying the fiel lib/base.php we create an other failure. The easiest way (but not the proper) is to disable the integrity control by modifyng the value of $OC_Channel in version.php to sth other than 'stable'...
PS : It will be easiest to contribute if you open the issues system on your app, in any case thks for these great job